### PR TITLE
To bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ version = "0.1.6"
 dependencies = [
  "dirs",
  "futures-core",
+ "memchr",
  "serde",
  "serde_json",
  "sysinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 dirs = "6.0.0"
 futures-core = "0.3.31"
+memchr = "2.7.6"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 sysinfo = "0.36.1"

--- a/src/lsp/binding.rs
+++ b/src/lsp/binding.rs
@@ -1,5 +1,5 @@
 use crate::{config::ProxyConfig, proxy::Pair};
-use memchr::memmem::find_iter;
+use memchr::memmem::{find, find_iter};
 use serde_json::{Value, json};
 use std::{path::PathBuf, process::Stdio, str, sync::Arc};
 use tokio::{
@@ -34,22 +34,21 @@ pub fn redirect_uri(
         }
     }
 
-    trace!(?from_path, ?to_path);
+    trace!(from=?String::from_utf8(from_path.to_vec()), to=?String::from_utf8(to_path.to_vec()));
 
     let occurrences = find_iter(&raw_bytes, from_path);
     let from_n = from_path.len();
     let mut new_bytes: Bytes = Bytes::new();
+    let mut last = 0;
 
     for occurr in occurrences {
-        let before = if occurr > 0 {
-            &raw_bytes[..occurr]
-        } else {
-            &Bytes::new()
-        };
-        let after = &raw_bytes[occurr + from_n..];
+        let before = &raw_bytes[last..occurr];
+        last = occurr + from_n;
         // add the new text and join
-        new_bytes = Bytes::from([before, to_path, after].concat());
+        new_bytes = Bytes::from([&new_bytes, before, to_path].concat());
     }
+    let after = &raw_bytes[last..];
+    new_bytes = Bytes::from([&new_bytes, after].concat());
 
     *raw_bytes = new_bytes;
 
@@ -115,13 +114,13 @@ impl RequestTracker {
         self.map.write().await.insert(id, method.to_string());
     }
 
-    async fn take_if_match(&self, id: u64, expected: &str) -> bool {
+    async fn take_if_match(&self, id: u64) -> bool {
         let mut map = self.map.write().await;
-        let exists = map.get(&id).map(|m| m == expected).unwrap_or(false);
-        if exists {
+        if map.get(&id).is_some() {
             map.remove(&id);
+            return true;
         }
-        exists
+        false
     }
 
     pub async fn check_for_methods(
@@ -135,71 +134,73 @@ impl RequestTracker {
             return Ok(());
         }
 
-        //textDocument/declaration
-
         match pair {
             Pair::Server => {
-                let mut v: Value = serde_json::from_slice(&raw_bytes)?;
+                // Early return
+                if self.map.read().await.is_empty() {
+                    trace!("Nothing expecting response, skipping method");
+                    return Ok(());
+                }
+
+                let mut v: Value = serde_json::from_slice(raw_bytes.as_ref())?;
                 trace!(server_response=%v, "received");
 
                 // Check if this is a response to a tracked request
                 if let Some(id) = v.get("id").and_then(Value::as_u64) {
-                    for method in methods {
-                        debug!("Checking for {method} method");
+                    let matches = self.take_if_match(id).await;
+                    debug!(%matches);
+                    if matches {
+                        trace!(%id, "matches");
+                        if let Some(results) = v.get_mut("result").and_then(Value::as_array_mut) {
+                            trace!(?results);
+                            for result in results {
+                                if let Some(uri_val) = result.get("uri").and_then(|u| u.as_str()) {
+                                    if !(uri_val.contains(&self.config.local_path)) {
+                                        debug!(%uri_val);
+                                        let new_uri = self.bind_library(uri_val).await?;
+                                        debug!("file://{}", new_uri);
 
-                        let matches = self.take_if_match(id, *method).await;
-                        debug!(%matches);
-                        if matches {
-                            trace!(%id, "matches");
-                            if let Some(results) = v.get_mut("result").and_then(Value::as_array_mut)
-                            {
-                                trace!(?results);
-                                for result in results {
-                                    if let Some(uri_val) =
-                                        result.get("uri").and_then(|u| u.as_str())
-                                    {
-                                        if !(uri_val.contains(&self.config.local_path)) {
-                                            debug!(%uri_val);
-                                            let new_uri =
-                                                self.bind_library(uri_val.to_string()).await?;
-                                            debug!("file://{}", new_uri);
-
-                                            Self::modify_uri(result, &new_uri);
-                                        }
+                                        Self::modify_uri(result, &new_uri);
                                     }
                                 }
-
-                                if let Some(vstr) = v.as_str() {
-                                    *raw_bytes = Bytes::from(vstr.as_bytes().to_owned());
-                                } else {
-                                    error!(%v ,"error converting to str");
-                                }
-                            } else {
-                                trace!("result content not found");
                             }
+
+                            *raw_bytes = Bytes::from(serde_json::to_vec(&v)?);
+                        } else {
+                            trace!("result content not found");
                         }
                     }
                 }
             }
 
             Pair::Client => {
-                let v: Value = serde_json::from_slice(&raw_bytes)?;
+                // Early check to avoid parsing
+                let mut method_found = "";
+                for method in methods {
+                    debug!("Checking for {method} method");
+                    let expected = &[b"\"method\":\"", method.as_bytes(), b"\""].concat();
+                    if find(raw_bytes, expected).is_some() {
+                        method_found = method;
+                        break;
+                    }
+                }
+
+                if method_found.is_empty() {
+                    debug!("Any method that required redirection was not found, skipping patch");
+                    return Ok(());
+                }
+
+                debug!(%method_found);
+
+                let v: Value = serde_json::from_slice(raw_bytes.as_ref())?;
                 trace!(client_request=%v, "received");
 
                 debug!("Checking for id");
                 if let Some(id) = v.get("id").and_then(Value::as_u64) {
                     debug!(%id);
-
-                    if let Some(req_method) = v.get("method").and_then(Value::as_str) {
-                        trace!(%req_method);
-                        // Only track expected methods if URI matches
-                        for method in methods {
-                            if req_method == *method {
-                                debug!(%id, "Storing");
-                                self.track(id, *method).await;
-                            }
-                        }
-                    }
+                    // Only track expected methods if URI matches
+                    self.track(id, method_found).await;
+                    debug!(%id, "Storing");
                 }
             }
         }
@@ -207,7 +208,7 @@ impl RequestTracker {
         Ok(())
     }
 
-    async fn bind_library(&self, uri: String) -> std::io::Result<String> {
+    async fn bind_library(&self, uri: &str) -> std::io::Result<String> {
         let temp_dir = std::env::temp_dir().join("lspdock");
         trace!(temp_dir=%temp_dir.to_string_lossy());
 
@@ -222,7 +223,7 @@ impl RequestTracker {
         } else {
             let relative_path = safe_path.strip_prefix("/").unwrap_or(&safe_path);
             trace!(%relative_path);
-            let tmp_file_path = relative_path.to_string();
+            let tmp_file_path = relative_path;
             temp_dir.join(tmp_file_path)
         };
 
@@ -238,7 +239,7 @@ impl RequestTracker {
         let temp_uri_path = PathBuf::from(&temp_uri);
         debug!(%temp_uri);
         if !temp_uri_path.exists() {
-            self.copy_file(safe_path.to_string(), &temp_uri).await?;
+            self.copy_file(&safe_path, &temp_uri).await?;
         } else {
             debug!("File already exists, skipping copy. {}", temp_uri);
         }
@@ -247,7 +248,7 @@ impl RequestTracker {
     }
 
     /// Copies a file from either the local filesystem or a Docker container.
-    async fn copy_file(&self, path: String, destination: &str) -> std::io::Result<()> {
+    async fn copy_file(&self, path: &str, destination: &str) -> std::io::Result<()> {
         // Only copy the file if the LSP is in a container
         debug!("Starting file copy from {} to {}", path, destination);
         let cmd = Command::new("docker")

--- a/src/lsp/parser.rs
+++ b/src/lsp/parser.rs
@@ -1,12 +1,15 @@
+use memchr::memmem::find;
 use std::error::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader};
-use tokio_util::bytes::{Buf, BytesMut};
-use tracing::{debug, error, trace, warn};
+use tokio_util::bytes::{Buf, Bytes, BytesMut};
+use tracing::{debug, trace};
 
 pub struct LspFramedReader<R> {
     reader: BufReader<R>,
     buffer: BytesMut,
 }
+
+const MAX_CONTENT_LENGTH: usize = 16 * 1024 * 1024;
 
 impl<R: AsyncRead + Unpin> LspFramedReader<R> {
     pub fn new(inner: R) -> Self {
@@ -40,110 +43,99 @@ impl<R: AsyncRead + Unpin> LspFramedReader<R> {
     /// ```
     pub async fn read_messages(
         &mut self,
-    ) -> Result<Option<Vec<String>>, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Option<Vec<Bytes>>, Box<dyn Error + Send + Sync>> {
         let mut messages = Vec::new();
-        let n = self.reader.read_buf(&mut self.buffer).await?;
-        if n == 0 && self.buffer.is_empty() {
-            return Ok(None);
-        }
 
-        while let Some((message, advance)) = self.try_parse_message() {
-            self.buffer.advance(advance);
-            messages.push(message);
-        }
+        loop {
+            // parse all complete frames currently in buffer
+            let mut made_progress = false;
+            while let Some((message, advance)) = self.try_parse_message()? {
+                self.buffer.advance(advance);
+                messages.push(message);
+                made_progress = true;
+            }
+            if made_progress {
+                // return as a batch once we’ve produced something
+                return Ok(Some(messages));
+            }
 
-        Ok(Some(messages))
+            // need more bytes to complete the next frame
+            let n = self.reader.read_buf(&mut self.buffer).await?;
+            if n == 0 {
+                // EOF
+                if self.buffer.is_empty() {
+                    return Ok(None); // clean end
+                } else {
+                    return Err("unexpected EOF while reading LSP message".into());
+                }
+            }
+        }
     }
 
     /// Capture a message from the buffer.
     /// If the header, content-length, or body is None, return None and reset the FSM's state.
-    fn try_parse_message(&self) -> Option<(String, usize)> {
-        let header_end = self.find_header_end()?;
+    fn try_parse_message(&self) -> Result<Option<(Bytes, usize)>, Box<dyn Error + Send + Sync>> {
+        let header_end = match find(&self.buffer, b"\r\n\r\n") {
+            Some(h) => h + 4,
+            None => return Ok(None), // header incomplete
+        };
         trace!(header_end);
+
         let headers = &self.buffer[..header_end];
-
         let content_length = self.extract_content_length(headers)?;
-        let (body, advance) = self.extract_body(header_end, content_length)?;
-
-        Some((body, advance))
-    }
-
-    /// Find the end of the header, which is marked by `\r\n\r\n`
-    fn find_header_end(&self) -> Option<usize> {
-        for i in 3..self.buffer.len() {
-            if &self.buffer[i - 3..=i] == b"\r\n\r\n" {
-                return Some(i + 1);
-            }
+        if content_length > MAX_CONTENT_LENGTH {
+            return Err(format!(
+                "Content-Length {} exceeds limit {}",
+                content_length, MAX_CONTENT_LENGTH
+            )
+            .into());
         }
-        return None;
+
+        // body complete?
+        let message_start = header_end;
+        let message_end = match header_end.checked_add(content_length) {
+            Some(x) => x,
+            None => return Err("Content-Length overflow".into()),
+        };
+        if self.buffer.len() < message_end {
+            return Ok(None); // need more bytes
+        }
+
+        // Zero-copy-ish: slice then to_string
+        let body = self.buffer[message_start..message_end].to_vec();
+
+        Ok(Some((Bytes::from(body), message_end)))
     }
 
     /// Extract the content length value from the header
-    fn extract_content_length(&self, headers: &[u8]) -> Option<usize> {
-        let headers_str = String::from_utf8(headers.to_vec()).ok()?;
-        let mut content_length = None;
-
-        for line in headers_str.split("\r\n") {
-            if line.is_empty() {
-                continue;
-            }
-
-            trace!("Processing header line: '{}'", line);
-            if let Some(colon_pos) = line.find(':') {
-                let key = line[..colon_pos].trim();
-                let value = line[colon_pos + 1..].trim();
-
-                trace!("Header key: '{}', value: '{}'", key, value);
-
-                // Check for Content-Length with case-insensitive matching
-                if key.eq_ignore_ascii_case("content-length") {
-                    match value.parse::<usize>() {
-                        Ok(len) => {
-                            content_length = Some(len);
-                            break;
-                        }
-                        Err(e) => {
-                            error!("Failed to parse Content-Length '{}': {}", value, e);
-                            return None;
-                        }
-                    }
-                } else if !key.is_empty() {
-                    warn!("Wrong content length header: {}", key);
-                    return None;
+    fn extract_content_length(
+        &self,
+        headers: &[u8],
+    ) -> Result<usize, Box<dyn Error + Send + Sync>> {
+        let s = std::str::from_utf8(headers)?; // no allocation
+        for line in s.split("\r\n") {
+            if let Some(colon) = line.find(':') {
+                let (k, v) = (&line[..colon], &line[colon + 1..]);
+                if k.trim().eq_ignore_ascii_case("content-length") {
+                    return Ok(v.trim().parse::<usize>()?);
                 }
-            } else {
-                debug!("Header line without colon: '{}'", line);
+                // ignore other headers like Content-Type
             }
         }
-
-        content_length
-    }
-
-    /// Extract the body of the message. If the buffer doesn't have enough data to complete the body,
-    /// according to the content length, return None
-    fn extract_body(&self, header_end: usize, content_length: usize) -> Option<(String, usize)> {
-        let message_start = header_end;
-        let message_end = header_end + content_length;
-
-        if self.buffer.len() < message_end {
-            return None;
-        }
-
-        let message = String::from_utf8(self.buffer[message_start..message_end].to_vec()).ok()?;
-
-        Some((message, message_end))
+        Err("missing Content-Length header".into())
     }
 }
 
 /// Send a message from the proxy to the destination
 pub async fn send_message(
     writer: &mut tokio::io::BufWriter<impl tokio::io::AsyncWriteExt + Unpin>,
-    message: String,
+    message: &Bytes,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let len = message.as_bytes().len();
+    let len = message.len();
     debug!(%len, "Sending message");
-    trace!(%message);
-    let msg = format!("Content-Length: {len}\r\n\r\n{message}");
+    trace!(?message);
+    let message_str = String::from_utf8(message.to_vec())?;
+    let msg = format!("Content-Length: {len}\r\n\r\n{message_str}");
 
     writer.write_all(msg.as_bytes()).await?;
     writer.flush().await?;

--- a/src/lsp/parser.rs
+++ b/src/lsp/parser.rs
@@ -134,10 +134,15 @@ pub async fn send_message(
     let len = message.len();
     debug!(%len, "Sending message");
     trace!(?message);
-    let message_str = String::from_utf8(message.to_vec())?;
-    let msg = format!("Content-Length: {len}\r\n\r\n{message_str}");
+    let msg = &[
+        b"Content-Length: ",
+        len.to_string().as_bytes(),
+        b"\r\n\r\n",
+        &message,
+    ]
+    .concat();
 
-    writer.write_all(msg.as_bytes()).await?;
+    writer.write_all(msg).await?;
     writer.flush().await?;
 
     Ok(())

--- a/src/lsp/pid.rs
+++ b/src/lsp/pid.rs
@@ -2,7 +2,7 @@ use memchr::memmem::find;
 use serde_json::{Value, json};
 use sysinfo::{Pid, System};
 use tokio_util::{bytes::Bytes, sync::CancellationToken};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 pub struct PidHandler {
     pid: Option<u64>,
@@ -27,31 +27,24 @@ impl PidHandler {
         &mut self,
         raw_bytes: &mut Bytes,
     ) -> serde_json::error::Result<bool> {
-        if find(raw_bytes, br#""method":"initialize""#).is_some() {
-            debug!("Initialize method found, patching");
-            trace!(?raw_bytes, "before patch");
-
-            let mut v: Value = serde_json::from_slice(&raw_bytes)?;
-            if let Some(process_id) = v
-                .get_mut("params")
-                .and_then(|params| params.get_mut("processId"))
-            {
-                self.pid = process_id.as_u64();
-                trace!(self.pid, "captured PID");
-                *process_id = json!("null");
-            }
-
-            if let Some(vstr) = v.as_str() {
-                *raw_bytes = Bytes::from(vstr.as_bytes().to_owned());
-            } else {
-                error!(%v ,"error converting to str");
-            }
-
-            trace!(?raw_bytes, "patched");
-            return Ok(true);
+        if find(raw_bytes, br#""method":"initialize""#).is_none() {
+            trace!("Initialize method not found, skipping patch");
+            return Ok(false);
         }
-        trace!("Initialize method not found, skipping patch");
-        return Ok(false);
+
+        debug!("Initialize method found, patching");
+        trace!(?raw_bytes, "before patch");
+
+        let mut v: Value = serde_json::from_slice(raw_bytes.as_ref())?;
+        if let Some(process_id) = v.pointer_mut("/params/processId") {
+            self.pid = process_id.as_u64();
+            trace!(self.pid, "captured PID");
+            *process_id = json!("null");
+        }
+        *raw_bytes = Bytes::from(serde_json::to_vec(&v)?);
+
+        trace!(?raw_bytes, "patched");
+        return Ok(true);
     }
 
     /// Monitor periodically if the PID is running


### PR DESCRIPTION
    - Replace string conversions with direct byte operations for efficiency
    - Simplify method matching using memchr::find for lower overhead
    - Refactor request tracking to remove unnecessary expected argument
    - Use pointer_mut for JSON mutation in pid handler
    - Avoid redundant error handling and conversions
    - Reduce allocations in send_message by writing bytes directly
